### PR TITLE
Use bcdata::bcdc_get_geodata to get population units

### DIFF
--- a/01_load.R
+++ b/01_load.R
@@ -13,7 +13,7 @@
 # Loading R libraries
 Packages <- c("sf", "tidyverse", "dplyr", "maptools", "devtools","bcmaps",
               "ggplot2", "leaflet", "rmapshaper", "jsonlite", "geojsonio",
-              "mapview", "readr")
+              "mapview", "readr", "bcdata")
 lapply(Packages, library, character.only = TRUE)
 
 # Source functions
@@ -39,7 +39,9 @@ bec <- bec()
 bears <- read_csv("https://catalogue.data.gov.bc.ca/dataset/2bf91935-9158-4f77-9c2c-4310480e6c29/resource/4eca8c5c-ed25-46c1-835c-3d9f84b807e1/download/grizzlypopulationestimate2012.csv")
 
 # Load grizzly bear population units as an sf object using `bcdc_map`
-popunits <- bcdc_map("WHSE_WILDLIFE_INVENTORY.GCPB_GRIZZLY_BEAR_POP_UNITS_SP")
+popunits <- bcdc_get_geodata("grizzly-bear-population-units",
+                             query = "VERSION_NAME='2012'")
+
 plot(st_geometry(popunits))
 
 # # Load grizzly bear population units as an sfc object


### PR DESCRIPTION
I fixed the `bcdata` package, so this should work now. You can install with `remotes::install_github("bcgov/bcdata")`. You'll notice that you can actually make the query right in the function call so you only pull down the boundary version that you need.

Let me know if it works for you!